### PR TITLE
fix: AdaptiveScreen actions

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -15,10 +15,10 @@
       </SelectionState>
       <SelectionState runConfigName="Personal.MovieCatalog.app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-02-24T22:07:16.122082Z">
+        <DropdownSelection timestamp="2025-03-06T08:24:31.510661Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/eky/.android/avd/Pixel7-Api30.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/eky/.android/avd/Pixel_Tablet_API_34.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/.tools/detekt/baseline.xml
+++ b/.tools/detekt/baseline.xml
@@ -4,6 +4,8 @@
   <CurrentIssues>
     <ID>ComposableEventParameterNaming:MediaPlayer.kt$onIsFullscreenChanged: (Boolean) -&gt; Unit</ID>
     <ID>CyclomaticComplexMethod:MovieDetailMapper.kt$MovieDetailMapper$fun mapToDomain(dto: MovieDetailDto): MovieDetail</ID>
+    <ID>LongParameterList:MediaPlayer.kt$( context: Context, exoPlayer: ExoPlayer, isFullscreen: Boolean, isTablet: Boolean, isLandscape: Boolean, onFullscreenToggle: (Boolean) -&gt; Unit, )</ID>
+    <ID>LongParameterList:MediaPlayer.kt$( playerView: PlayerView, exoPlayer: ExoPlayer, isFullscreen: Boolean, isTablet: Boolean, isLandscape: Boolean, onFullscreenToggle: (Boolean) -&gt; Unit )</ID>
     <ID>MatchingDeclarationName:AdaptiveJourneyNavigation.kt$AdaptiveJourney : Screen</ID>
     <ID>MatchingDeclarationName:AdaptiveNav.kt$Adaptive : Screen</ID>
     <ID>MatchingDeclarationName:DetailNav.kt$Detail : Screen</ID>
@@ -11,7 +13,7 @@
     <ID>MatchingDeclarationName:MainJourneyNavigation.kt$MainJourney : Screen</ID>
     <ID>MatchingDeclarationName:PlayerNav.kt$Player : Screen</ID>
     <ID>MatchingDeclarationName:SplashNav.kt$Splash : Screen</ID>
-    <ID>ModifierReused:MediaPlayer.kt$AndroidView( modifier = modifier, factory = { ctx -&gt; createPlayerView( ctx, exoPlayer, isFullscreen, isLandscape, onFullscreenToggle, ).also { playerView -&gt; onPlayerViewCreate(playerView) } }, update = { playerView -&gt; updatePlayerView( playerView, exoPlayer, isFullscreen, isLandscape, onFullscreenToggle ) } )</ID>
+    <ID>ModifierReused:MediaPlayer.kt$AndroidView( modifier = modifier, factory = { ctx -&gt; createPlayerView( ctx, exoPlayer, isFullscreen, isTablet, isLandscape, onFullscreenToggle, ).also { playerView -&gt; onPlayerViewCreate(playerView) } }, update = { playerView -&gt; updatePlayerView( playerView, exoPlayer, isFullscreen, isTablet, isLandscape, onFullscreenToggle ) } )</ID>
     <ID>ModifierReused:MediaPlayer.kt$Box( modifier = modifier, contentAlignment = Alignment.Center ) { Text( text = stringResource(R.string.label_player_not_available), color = MaterialTheme.colorScheme.onSecondary ) }</ID>
     <ID>UnstableCollections:GenreItem.kt$List&lt;Genre&gt;?</ID>
   </CurrentIssues>

--- a/core/navigation/src/main/java/dev/enesky/core/navigation/AdaptiveJourneyNavigation.kt
+++ b/core/navigation/src/main/java/dev/enesky/core/navigation/AdaptiveJourneyNavigation.kt
@@ -6,6 +6,8 @@ import androidx.navigation.compose.navigation
 import dev.enesky.core.ui.navigation.Screen
 import dev.enesky.feature.adaptive.navigation.Adaptive
 import dev.enesky.feature.adaptive.navigation.adaptiveScreen
+import dev.enesky.feature.player.navigation.Player
+import dev.enesky.feature.player.navigation.playerScreen
 import dev.enesky.feature.splash.navigation.Splash
 import dev.enesky.feature.splash.navigation.splashScreen
 import kotlinx.serialization.Serializable
@@ -18,7 +20,7 @@ import kotlinx.serialization.Serializable
 object AdaptiveJourney : Screen
 
 internal fun NavGraphBuilder.adaptiveJourneyNavigation(navController: NavHostController) {
-    navigation<MainJourney>(startDestination = Splash) {
+    navigation<AdaptiveJourney>(startDestination = Splash) {
         splashScreen(
             onNavigateToHome = {
                 navController.onScreenNavigate(
@@ -28,6 +30,11 @@ internal fun NavGraphBuilder.adaptiveJourneyNavigation(navController: NavHostCon
                 )
             }
         )
-        adaptiveScreen()
+        adaptiveScreen(
+            onNavigateToPlayerScreen = {
+                navController.onScreenNavigate(Player())
+            }
+        )
+        playerScreen()
     }
 }

--- a/core/navigation/src/main/java/dev/enesky/core/navigation/MovieCatalogNavGraph.kt
+++ b/core/navigation/src/main/java/dev/enesky/core/navigation/MovieCatalogNavGraph.kt
@@ -18,14 +18,15 @@ fun MovieCatalogNavGraph(
     modifier: Modifier = Modifier,
 ) {
     val isTablet = booleanResource(id = dev.enesky.core.ui.R.bool.isTablet)
+    val startDest = if (isTablet) AdaptiveJourney else MainJourney
     NavHost(
         navController = navController,
-        startDestination = MainJourney,
+        startDestination = startDest,
         modifier = modifier,
     ) {
         when (isTablet) {
-            false -> mainJourneyNavigation(navController)
             true -> adaptiveJourneyNavigation(navController)
+            false -> mainJourneyNavigation(navController)
         }
     }
 }

--- a/feature/adaptive/src/main/java/dev/enesky/feature/adaptive/AdaptiveScreen.kt
+++ b/feature/adaptive/src/main/java/dev/enesky/feature/adaptive/AdaptiveScreen.kt
@@ -14,19 +14,17 @@ import androidx.compose.material3.adaptive.layout.ThreePaneScaffoldDestinationIt
 import androidx.compose.material3.adaptive.layout.calculatePaneScaffoldDirective
 import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.enesky.core.common.utils.ObserveAsEvents
-import dev.enesky.core.domain.model.MovieDetail
+import dev.enesky.feature.detail.DetailEvent
 import dev.enesky.feature.detail.DetailScreen
-import dev.enesky.feature.detail.DetailViewModel
+import dev.enesky.feature.detail.DetailUiState
+import dev.enesky.feature.home.HomeEvent
 import dev.enesky.feature.home.HomeScreen
-import dev.enesky.feature.home.HomeViewModel
+import dev.enesky.feature.home.HomeUiState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 
@@ -37,16 +35,30 @@ import kotlinx.coroutines.flow.emptyFlow
 fun AdaptiveScreen(
     modifier: Modifier = Modifier,
     uiState: AdaptiveUiState = AdaptiveUiState(),
-    homeViewModel: HomeViewModel = hiltViewModel(),
-    detailViewModel: DetailViewModel = hiltViewModel(),
+    homeUiState: HomeUiState,
+    detailUiState: DetailUiState,
     eventFlow: Flow<AdaptiveEvent> = emptyFlow(),
+    homeEventFlow: Flow<HomeEvent> = emptyFlow(),
+    detailEventFlow: Flow<DetailEvent> = emptyFlow(),
+    onHomeRefresh: () -> Unit = {},
+    onDetailRefresh: () -> Unit = {},
+    onMovieClick: (Int) -> Unit = {},
+    onNavigateToPlayerScreen: (Int) -> Unit = {},
 ) {
-    val detailUiState by detailViewModel.uiState.collectAsStateWithLifecycle()
-    val homeUiState by homeViewModel.uiState.collectAsStateWithLifecycle()
-
     ObserveAsEvents(eventFlow) { adaptiveEvent ->
         when (adaptiveEvent) {
             is AdaptiveEvent.OnError -> { /* Handle error */ }
+        }
+    }
+    ObserveAsEvents(homeEventFlow) { homeEvent ->
+        when (homeEvent) {
+            is HomeEvent.OnError -> { /* Handle error */ }
+            is HomeEvent.OnMovieClick -> onMovieClick(homeEvent.movieId)
+        }
+    }
+    ObserveAsEvents(detailEventFlow) { detailEvent ->
+        when (detailEvent) {
+            is DetailEvent.OnError -> { /* Handle error */ }
         }
     }
 
@@ -54,18 +66,21 @@ fun AdaptiveScreen(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background),
+        uiState = uiState,
         homeContent = {
             HomeScreen(
                 uiState = homeUiState,
-                eventFlow = homeViewModel.eventFlow,
-                onRefresh = { homeViewModel.getConfig() }
+                eventFlow = homeEventFlow,
+                onRefresh = onHomeRefresh,
+                onMovieClick = onMovieClick,
             )
         },
         detailContent = {
             DetailScreen(
                 uiState = detailUiState,
-                eventFlow = detailViewModel.eventFlow,
-                onRefresh = { detailViewModel.getMovieDetails() },
+                eventFlow = detailEventFlow,
+                onRefresh = onDetailRefresh,
+                onNavigateToPlayerScreen = onNavigateToPlayerScreen
             )
         }
     )
@@ -75,11 +90,10 @@ fun AdaptiveScreen(
 @Composable
 fun AdaptiveContent(
     modifier: Modifier = Modifier,
-    movieDetail: MovieDetail? = null,
-    onMovieClick: (String) -> Unit = {},
-    onBackClick: () -> Unit = {},
+    uiState: AdaptiveUiState,
     homeContent: @Composable () -> Unit = {},
     detailContent: @Composable () -> Unit = {},
+    onBackClick: () -> Unit = {},
     windowAdaptiveInfo: WindowAdaptiveInfo = currentWindowAdaptiveInfo(),
 ) {
     val listDetailNavigator = rememberListDetailPaneScaffoldNavigator(
@@ -95,6 +109,7 @@ fun AdaptiveContent(
 
     val homeScreenWidth = calculateHomeScreenWidth()
     ListDetailPaneScaffold(
+        modifier = modifier,
         value = listDetailNavigator.scaffoldValue,
         directive = listDetailNavigator.scaffoldDirective,
         listPane = {
@@ -114,6 +129,6 @@ fun AdaptiveContent(
 private fun calculateHomeScreenWidth(): Dp {
     val config = LocalConfiguration.current
     val screenWidth = config.screenWidthDp.dp
-    val listScreenMultiplier = 0.6f
+    val listScreenMultiplier = 0.55f
     return screenWidth * listScreenMultiplier
 }

--- a/feature/adaptive/src/main/java/dev/enesky/feature/adaptive/AdaptiveScreen.kt
+++ b/feature/adaptive/src/main/java/dev/enesky/feature/adaptive/AdaptiveScreen.kt
@@ -33,10 +33,10 @@ import kotlinx.coroutines.flow.emptyFlow
  */
 @Composable
 fun AdaptiveScreen(
-    modifier: Modifier = Modifier,
-    uiState: AdaptiveUiState = AdaptiveUiState(),
     homeUiState: HomeUiState,
     detailUiState: DetailUiState,
+    modifier: Modifier = Modifier,
+    uiState: AdaptiveUiState = AdaptiveUiState(),
     eventFlow: Flow<AdaptiveEvent> = emptyFlow(),
     homeEventFlow: Flow<HomeEvent> = emptyFlow(),
     detailEventFlow: Flow<DetailEvent> = emptyFlow(),
@@ -89,8 +89,8 @@ fun AdaptiveScreen(
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
 fun AdaptiveContent(
-    modifier: Modifier = Modifier,
     uiState: AdaptiveUiState,
+    modifier: Modifier = Modifier,
     homeContent: @Composable () -> Unit = {},
     detailContent: @Composable () -> Unit = {},
     onBackClick: () -> Unit = {},

--- a/feature/adaptive/src/main/java/dev/enesky/feature/adaptive/AdaptiveViewModel.kt
+++ b/feature/adaptive/src/main/java/dev/enesky/feature/adaptive/AdaptiveViewModel.kt
@@ -15,8 +15,8 @@ import javax.inject.Inject
  * Created by Enes Kamil YILMAZ on 24/02/2025
  */
 @HiltViewModel
-class AdaptiveViewModel @Inject constructor(savedStateHandle: SavedStateHandle)
-    : BaseViewModel<AdaptiveUiState, AdaptiveEvent>(initialState = { AdaptiveUiState() }) {
+class AdaptiveViewModel @Inject constructor(savedStateHandle: SavedStateHandle) :
+    BaseViewModel<AdaptiveUiState, AdaptiveEvent>(initialState = { AdaptiveUiState() }) {
     init {
         val args: Adaptive = savedStateHandle.toRoute()
     }

--- a/feature/adaptive/src/main/java/dev/enesky/feature/adaptive/AdaptiveViewModel.kt
+++ b/feature/adaptive/src/main/java/dev/enesky/feature/adaptive/AdaptiveViewModel.kt
@@ -8,7 +8,6 @@ import dev.enesky.core.common.data.base.BaseViewModel
 import dev.enesky.core.common.data.delegate.IErrorEvent
 import dev.enesky.core.common.data.delegate.IEvent
 import dev.enesky.core.common.data.delegate.IUiState
-import dev.enesky.core.domain.usecase.GetMovieDetailsUseCase
 import dev.enesky.feature.adaptive.navigation.Adaptive
 import javax.inject.Inject
 
@@ -16,13 +15,8 @@ import javax.inject.Inject
  * Created by Enes Kamil YILMAZ on 24/02/2025
  */
 @HiltViewModel
-class AdaptiveViewModel @Inject constructor(
-    private val getMovieDetailsUseCase: GetMovieDetailsUseCase,
-    savedStateHandle: SavedStateHandle
-) : BaseViewModel<AdaptiveUiState, AdaptiveEvent>(
-    initialState = { AdaptiveUiState() }
-) {
-
+class AdaptiveViewModel @Inject constructor(savedStateHandle: SavedStateHandle)
+    : BaseViewModel<AdaptiveUiState, AdaptiveEvent>(initialState = { AdaptiveUiState() }) {
     init {
         val args: Adaptive = savedStateHandle.toRoute()
     }

--- a/feature/adaptive/src/main/java/dev/enesky/feature/adaptive/navigation/AdaptiveNav.kt
+++ b/feature/adaptive/src/main/java/dev/enesky/feature/adaptive/navigation/AdaptiveNav.kt
@@ -8,6 +8,8 @@ import androidx.navigation.compose.composable
 import dev.enesky.core.ui.navigation.Screen
 import dev.enesky.feature.adaptive.AdaptiveScreen
 import dev.enesky.feature.adaptive.AdaptiveViewModel
+import dev.enesky.feature.detail.DetailViewModel
+import dev.enesky.feature.home.HomeViewModel
 import kotlinx.serialization.Serializable
 
 /**
@@ -17,13 +19,27 @@ import kotlinx.serialization.Serializable
 @Serializable
 data object Adaptive : Screen
 
-fun NavGraphBuilder.adaptiveScreen() {
+fun NavGraphBuilder.adaptiveScreen(
+    onNavigateToPlayerScreen: (Int) -> Unit = {}
+) {
     composable<Adaptive> {
         val viewModel = hiltViewModel<AdaptiveViewModel>()
+        val homeViewModel = hiltViewModel<HomeViewModel>()
+        val detailViewModel = hiltViewModel<DetailViewModel>()
         val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+        val homeUiState by homeViewModel.uiState.collectAsStateWithLifecycle()
+        val detailUiState by detailViewModel.uiState.collectAsStateWithLifecycle()
         AdaptiveScreen(
             uiState = uiState,
-            eventFlow = viewModel.eventFlow
+            homeUiState = homeUiState,
+            detailUiState = detailUiState,
+            eventFlow = viewModel.eventFlow,
+            homeEventFlow = homeViewModel.eventFlow,
+            detailEventFlow = detailViewModel.eventFlow,
+            onHomeRefresh = { homeViewModel.getConfig() },
+            onDetailRefresh = { detailViewModel.getMovieDetails() },
+            onMovieClick = { detailViewModel.getMovieDetails(it) },
+            onNavigateToPlayerScreen = onNavigateToPlayerScreen
         )
     }
 }

--- a/feature/detail/src/main/java/dev/enesky/feature/detail/DetailViewModel.kt
+++ b/feature/detail/src/main/java/dev/enesky/feature/detail/DetailViewModel.kt
@@ -33,7 +33,7 @@ class DetailViewModel @Inject constructor(
         getMovieDetails()
     }
 
-    fun getMovieDetails() {
+    fun getMovieDetails(movieId: Int? = null) {
         viewModelScope.launch(Dispatchers.IO) {
             val args: Detail = try {
                 savedStateHandle.toRoute()
@@ -41,7 +41,7 @@ class DetailViewModel @Inject constructor(
                 Detail(movieId = RemoteConfigManager.Values.previewMovieId.toInt())
             }
             updateUiState { copy(isLoading = true) }
-            getMovieDetailUseCase.invoke(id = args.movieId).fold(
+            getMovieDetailUseCase.invoke(id = movieId ?: args.movieId).fold(
                 onSuccess = {
                     updateUiState {
                         copy(

--- a/feature/home/src/main/java/dev/enesky/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/dev/enesky/feature/home/HomeScreen.kt
@@ -63,7 +63,8 @@ fun HomeScreen(
         topRatedMovies = topRatedMovies,
         upcomingMovies = upcomingMovies,
         onRefresh = onRefresh,
-        onMovieClick = onNavigateToDetail,
+        onMovieClick = onMovieClick,
+        onNavigateToDetail = onNavigateToDetail,
     )
 }
 
@@ -79,6 +80,7 @@ fun HomeContent(
     upcomingMovies: LazyPagingItems<Movie>? = null,
     onRefresh: () -> Unit = {},
     onMovieClick: (Int) -> Unit = {},
+    onNavigateToDetail: (Int) -> Unit = {},
 ) {
     fun isRefreshing() = nowPlayingMovies?.loadState?.refresh?.isLoading == true ||
             popularMovies?.loadState?.refresh?.isLoading == true ||
@@ -93,6 +95,11 @@ fun HomeContent(
         upcomingMovies?.refresh()
     }
     val listState = rememberLazyListState()
+
+    val onClick: (Int) -> Unit = { movieId ->
+        onMovieClick(movieId)
+        onNavigateToDetail(movieId)
+    }
 
     SwipeRefresh(
         modifier = modifier.fillMaxSize(),
@@ -111,35 +118,35 @@ fun HomeContent(
                 MoviePreview(
                     isLoading = isConfigLoaded.not(),
                     movieDetail = movieDetail,
-                    onMovieClick = onMovieClick,
+                    onMovieClick = onClick,
                 )
             }
             item {
                 MoviePagingRow(
                     title = stringResource(id = R.string.label_now_playing),
                     pagingItems = nowPlayingMovies,
-                    onMovieClick = onMovieClick,
+                    onMovieClick = onClick,
                 )
             }
             item {
                 MoviePagingRow(
                     title = stringResource(id = R.string.label_popular),
                     pagingItems = popularMovies,
-                    onMovieClick = onMovieClick,
+                    onMovieClick = onClick,
                 )
             }
             item {
                 MoviePagingRow(
                     title = stringResource(id = R.string.label_top_rated),
                     pagingItems = topRatedMovies,
-                    onMovieClick = onMovieClick,
+                    onMovieClick = onClick,
                 )
             }
             item {
                 MoviePagingRow(
                     title = stringResource(id = R.string.label_upcoming),
                     pagingItems = upcomingMovies,
-                    onMovieClick = onMovieClick,
+                    onMovieClick = onClick,
                 )
             }
         }

--- a/feature/home/src/main/java/dev/enesky/feature/home/components/MoviePreview.kt
+++ b/feature/home/src/main/java/dev/enesky/feature/home/components/MoviePreview.kt
@@ -135,8 +135,8 @@ private fun calculateMoviePreviewHeight(): Dp {
     val screenWidth = config.screenWidthDp.dp
     val screenHeight = config.screenHeightDp.dp
     val landscapeWidthMultiplier = 0.4f
-    val landscapeHeightMultiplier = 0.7f
-    val portraitMultiplier = 0.75f
+    val landscapeHeightMultiplier = 0.6f
+    val portraitMultiplier = 0.7f
 
     // In landscape, limit the height based on available screen height
     return if (isLandscape) {

--- a/feature/player/src/main/java/dev/enesky/feature/player/PlayerScreen.kt
+++ b/feature/player/src/main/java/dev/enesky/feature/player/PlayerScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.booleanResource
 import dev.enesky.core.common.utils.ObserveAsEvents
 import dev.enesky.core.domain.constant.MovieConstants
 import dev.enesky.core.domain.model.MovieDetail
@@ -49,7 +50,8 @@ fun PlayerContent(
     modifier: Modifier = Modifier,
     movieDetail: MovieDetail? = null
 ) {
-    var isFullscreen by rememberSaveable { mutableStateOf(false) }
+    val isTablet = booleanResource(id = dev.enesky.core.ui.R.bool.isTablet)
+    var isFullscreen by rememberSaveable { mutableStateOf(isTablet) }
 
     LazyColumn(modifier = modifier.fillMaxSize()) {
         item {
@@ -61,7 +63,7 @@ fun PlayerContent(
                 isInFullscreenMode = isFullscreen
             )
         }
-        if (isFullscreen.not()) {
+        if (isFullscreen.not() || isTablet) {
             item {
                 MovieDetails(movieDetail = movieDetail)
             }

--- a/feature/player/src/main/java/dev/enesky/feature/player/PlayerViewModel.kt
+++ b/feature/player/src/main/java/dev/enesky/feature/player/PlayerViewModel.kt
@@ -10,6 +10,7 @@ import dev.enesky.core.common.data.delegate.IErrorEvent
 import dev.enesky.core.common.data.delegate.IEvent
 import dev.enesky.core.common.data.delegate.IUiState
 import dev.enesky.core.common.data.fold
+import dev.enesky.core.common.remoteconfig.RemoteConfigManager
 import dev.enesky.core.domain.model.MovieDetail
 import dev.enesky.core.domain.usecase.GetMovieDetailsUseCase
 import dev.enesky.feature.player.navigation.Player
@@ -23,40 +24,41 @@ import javax.inject.Inject
 @HiltViewModel
 class PlayerViewModel @Inject constructor(
     private val getMovieDetailsUseCase: GetMovieDetailsUseCase,
-    savedStateHandle: SavedStateHandle
+    private val savedStateHandle: SavedStateHandle
 ) : BaseViewModel<PlayerUiState, PlayerEvent>(
     initialState = { PlayerUiState() }
 ) {
 
     init {
-        val args: Player = savedStateHandle.toRoute()
-        viewModelScope.launch(Dispatchers.IO) {
-            getMovieDetails(args.movieId)
-        }
+        getMovieDetails()
     }
 
-    private suspend fun getMovieDetails(movieId: Int) {
-        updateUiState { copy(isLoading = true) }
-        getMovieDetailsUseCase.invoke(id = movieId).fold(
-            onSuccess = {
-                updateUiState {
-                    copy(
-                        isLoading = false,
-                        movieDetail = it,
-                        errorMessage = null
-                    )
+    private fun getMovieDetails() {
+        viewModelScope.launch(Dispatchers.IO) {
+            updateUiState { copy(isLoading = true) }
+            val args: Player? = savedStateHandle.toRoute()
+            val id = args?.movieId ?: RemoteConfigManager.Values.previewMovieId.toInt()
+            getMovieDetailsUseCase.invoke(id = id).fold(
+                onSuccess = {
+                    updateUiState {
+                        copy(
+                            isLoading = false,
+                            movieDetail = it,
+                            errorMessage = null
+                        )
+                    }
+                },
+                onError = {
+                    updateUiState {
+                        copy(
+                            isLoading = false,
+                            movieDetail = null,
+                            errorMessage = it.message
+                        )
+                    }
                 }
-            },
-            onError = {
-                updateUiState {
-                    copy(
-                        isLoading = false,
-                        movieDetail = null,
-                        errorMessage = it.message
-                    )
-                }
-            }
-        )
+            )
+        }
     }
 }
 

--- a/feature/player/src/main/java/dev/enesky/feature/player/components/MediaPlayer.kt
+++ b/feature/player/src/main/java/dev/enesky/feature/player/components/MediaPlayer.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.booleanResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -64,6 +65,7 @@ fun MediaPlayer(
     val context = LocalContext.current
     val configuration = LocalConfiguration.current
     val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+    val isTablet = booleanResource(id = dev.enesky.core.ui.R.bool.isTablet)
     val systemUiController = rememberSystemUiController()
     var isFullscreen by rememberSaveable { mutableStateOf(isLandscape || isInFullscreenMode) }
     var playerView by remember { mutableStateOf<PlayerView?>(null) }
@@ -74,6 +76,7 @@ fun MediaPlayer(
     HandleFullscreenChanges(
         isFullscreen = isFullscreen,
         isInFullscreenMode = isInFullscreenMode,
+        isTablet = isTablet,
         isLandscape = isLandscape,
         systemUiController = systemUiController,
         context = context,
@@ -91,14 +94,14 @@ fun MediaPlayer(
         // This will trigger recomposition and update the AndroidView when fullscreen mode changes
     }
 
-    val playerModifier = modifier
-        .fillMaxWidth()
-        .height(calculateMoviePreviewHeight())
-
     MediaPlayerContent(
-        modifier = playerModifier.background(MovieCatalogTheme.colors.dark),
+        modifier = modifier
+            .fillMaxWidth()
+            .height(calculateMoviePreviewHeight())
+            .background(MovieCatalogTheme.colors.dark),
         exoPlayer = exoPlayer,
         isFullscreen = isFullscreen,
+        isTablet = isTablet,
         onFullscreenToggle = { fullscreen ->
             isFullscreen = fullscreen
             onFullscreenChange(fullscreen)
@@ -177,6 +180,7 @@ private fun LoadMediaContent(exoPlayer: ExoPlayer?, context: Context) {
 private fun HandleFullscreenChanges(
     isFullscreen: Boolean,
     isInFullscreenMode: Boolean,
+    isTablet: Boolean,
     isLandscape: Boolean,
     systemUiController: SystemUiController,
     context: Context,
@@ -187,7 +191,7 @@ private fun HandleFullscreenChanges(
         val newFullscreenState = isFullscreen || isInFullscreenMode
         onIsFullscreenChanged(newFullscreenState)
 
-        if (newFullscreenState) {
+        if (newFullscreenState || isTablet) {
             systemUiController.isSystemBarsVisible = false
             setLandscapeMode(context)
         } else {
@@ -239,6 +243,7 @@ private fun MediaPlayerContent(
     exoPlayer: ExoPlayer?,
     modifier: Modifier = Modifier,
     isFullscreen: Boolean = false,
+    isTablet: Boolean = false,
     onFullscreenToggle: (Boolean) -> Unit = {},
     onPlayerViewCreate: (PlayerView) -> Unit = {}
 ) {
@@ -267,6 +272,7 @@ private fun MediaPlayerContent(
                 ctx,
                 exoPlayer,
                 isFullscreen,
+                isTablet,
                 isLandscape,
                 onFullscreenToggle,
             ).also { playerView ->
@@ -278,6 +284,7 @@ private fun MediaPlayerContent(
                 playerView,
                 exoPlayer,
                 isFullscreen,
+                isTablet,
                 isLandscape,
                 onFullscreenToggle
             )
@@ -321,6 +328,7 @@ private fun createPlayerView(
     context: Context,
     exoPlayer: ExoPlayer,
     isFullscreen: Boolean,
+    isTablet: Boolean,
     isLandscape: Boolean,
     onFullscreenToggle: (Boolean) -> Unit,
 ): PlayerView {
@@ -329,6 +337,7 @@ private fun createPlayerView(
         setFullscreenButtonClickListener {
             onFullscreenToggle(!isFullscreen)
         }
+        setFullscreenButtonState((isTablet && isLandscape).not())
         resizeMode = getResizeMode(isFullscreen, isLandscape)
         controllerAutoShow = true
         controllerShowTimeoutMs = MediaConstants.TIMEOUT_MS
@@ -346,21 +355,25 @@ private fun updatePlayerView(
     playerView: PlayerView,
     exoPlayer: ExoPlayer,
     isFullscreen: Boolean,
+    isTablet: Boolean,
     isLandscape: Boolean,
     onFullscreenToggle: (Boolean) -> Unit
 ) {
-    playerView.player = exoPlayer
-    playerView.resizeMode = getResizeMode(isFullscreen, isLandscape)
+    playerView.apply {
+        player = exoPlayer
+        resizeMode = getResizeMode(isFullscreen, isLandscape)
 
-    // Important: Update the fullscreen button click listener to reflect current state
-    playerView.setFullscreenButtonClickListener {
-        onFullscreenToggle(!isFullscreen)
-    }
+        // Important: Update the fullscreen button click listener to reflect current state
+        setFullscreenButtonClickListener {
+            onFullscreenToggle(!isFullscreen)
+        }
+        setFullscreenButtonState((isTablet && isLandscape).not())
 
-    if (isFullscreen || isLandscape) {
-        playerView.layoutParams = playerView.layoutParams.apply {
-            width = -1 // MATCH_PARENT
-            height = -1 // MATCH_PARENT
+        if (isFullscreen || isLandscape) {
+            layoutParams = playerView.layoutParams.apply {
+                width = -1 // MATCH_PARENT
+                height = -1 // MATCH_PARENT
+            }
         }
     }
 }

--- a/feature/player/src/main/java/dev/enesky/feature/player/navigation/PlayerNav.kt
+++ b/feature/player/src/main/java/dev/enesky/feature/player/navigation/PlayerNav.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class Player(
-    val movieId: Int
+    val movieId: Int? = null
 ) : Screen
 
 fun NavGraphBuilder.playerScreen() {


### PR DESCRIPTION
## <sup><sup>[Mandatory] &#x1F534;</sup></sup> What's the change?
- Modified AdaptiveScreen and AdaptiveViewModel for better tablet support
- Refactored adaptive UI components to use new state and event flows
- Updated navigation logic to include player screen functionality

## <sup><sup>[Mandatory] &#x1F534;</sup></sup> Why do we need this change?
- To improve the overall user experience on larger screens
- To enable the split-screen view showing movie list and details simultaneously on tablets
- To streamline navigation between screens based on device type

## <sup><sup>[Necessary] &#x1F7E1;</sup></sup> Related issues / PRs / Jira tickets / Crashlytics links
- Started on top of https://github.com/enesky/MovieCatalog/pull/20
